### PR TITLE
Add searching as a tool instead of as resource 

### DIFF
--- a/server.py
+++ b/server.py
@@ -32,11 +32,14 @@ def fetch_index_details(index: str) -> dict[str, any]:
     return es_client.get_index_details(index)
 
 
-@mcp.resource(
-    uri="docs://search/{query}",
-    name="Elasticsearch Documentation",
-    description="Perform a semantic search across Elastic documentation for a given query.",
-)
+# ------------------- MCP Tools (Actions Users Can Trigger) -------------------
+
+
+#  IMO the search tools (semantic search) should be actually resources
+# 
+# TODO: define actual tools
+
+@mcp.tool()
 def search_elastic_documentation(query: str) -> dict[str, any]:
     """
     Perform a semantic search across Elastic documentation for a given query. The
@@ -44,14 +47,6 @@ def search_elastic_documentation(query: str) -> dict[str, any]:
     You will get titles and links to the documentation pages that might be helpful for user to understand the concepts.
     """
     return es_client.search_crawler_resource("search-elastic-docs", query)
-
-
-# ------------------- MCP Tools (Actions Users Can Trigger) -------------------
-
-
-#  IMO the search tools (semantic search) should be actually resources
-# 
-# TODO: define actual tools
 
 @mcp.tool()
 def search_elastic_search_labs_blogs(query: str) -> dict[str, any]:

--- a/server.py
+++ b/server.py
@@ -13,7 +13,7 @@ Message = Union[UserMessage, AssistantMessage]
 
 
 @mcp.resource(
-    "elasticsearch://indices",
+    uri="elasticsearch://indices",
     name="Elasticsearch Indices",
     description="Retrieve all Elasticsearch indices.",
 )
@@ -23,7 +23,7 @@ def fetch_indices() -> list[dict]:
 
 
 @mcp.resource(
-    "elasticsearch://indices/{index}",
+    uri="elasticsearch://indices/{index}",
     name="Index Details",
     description="Retrieve details of a specific Elasticsearch index.",
 )
@@ -33,7 +33,7 @@ def fetch_index_details(index: str) -> dict[str, any]:
 
 
 @mcp.resource(
-    "docs://search/{query}",
+    uri="docs://search/{query}",
     name="Elasticsearch Documentation",
     description="Perform a semantic search across Elastic documentation for a given query.",
 )
@@ -46,11 +46,14 @@ def search_elastic_documentation(query: str) -> dict[str, any]:
     return es_client.search_crawler_resource("search-elastic-docs", query)
 
 
-@mcp.resource(
-    "search_labs://search/{query}",
-    name="Elasticsearch Labs Blogs",
-    description="Perform a semantic search across Elastic search labs blogs for a given query.",
-)
+# ------------------- MCP Tools (Actions Users Can Trigger) -------------------
+
+
+#  IMO the search tools (semantic search) should be actually resources
+# 
+# TODO: define actual tools
+
+@mcp.tool()
 def search_elastic_search_labs_blogs(query: str) -> dict[str, any]:
     """
     Perform a semantic search across Elastic search labs blogs for a given query. The
@@ -59,12 +62,6 @@ def search_elastic_search_labs_blogs(query: str) -> dict[str, any]:
     """
     return es_client.search_crawler_resource("search-blog-search-labs", query)
 
-
-# ------------------- MCP Tools (Actions Users Can Trigger) -------------------
-
-
-#  IMO the search tools (semantic search) should be actually resources
-# TODO: define actual tools
 
 # ------------------- MCP Prompts (Predefined Interactions with the Assistant) -------------------
 
@@ -114,17 +111,36 @@ def analyze_salesforce_data(index: str) -> list[Message]:
 
 # ------------------- DEBUG: Print Registered Resources -------------------
 
-
 def debug_registered_resources():
     """Print all registered MCP resources for debugging."""
     print("\n🔍 Registered MCP Resources:")
     for resource in mcp._resource_manager.list_resources():
-        print(f" - {resource}")
+        print(f" - {resource.name}")
+    for resource in mcp._resource_manager.list_templates():
+        print(f" - {resource.name}")
+
+# ------------------- DEBUG: Print Registered Tools -------------------
+
+def debug_registered_tools():
+    """Print all registered MCP tools for debugging."""
+    print("\n🔍 Registered MCP Tools:")
+    for tool in mcp._tool_manager.list_tools():
+        print(f" - {tool.name}")
+
+# ------------------- DEBUG: Print Registered Prompts -------------------
+
+def debug_registered_prompts():
+    """Print all registered MCP prompts for debugging."""
+    print("\n🔍 Registered MCP Prompts:")
+    for prompt in mcp._prompt_manager.list_prompts():
+        print(f" - {prompt.name}")
 
 
 # ------------------- MCP Server Execution -------------------
 
 if __name__ == "__main__":
     debug_registered_resources()
-    print(f"MCP server '{mcp.name}' is running...")
+    debug_registered_prompts()
+    debug_registered_tools()
+    print(f"\n MCP server '{mcp.name}' is running...")
     mcp.run()


### PR DESCRIPTION
resources with parameter binding are resource templates not necessarily resources and it's a known issue that they're not being shown on Claude Ui https://github.com/modelcontextprotocol/python-sdk/issues/92 :disappointed: 

I'm thinking for at least demo purposes to have the searching be tools even though in this instance its getting data and resources are supposed to be used as GET endpoints and tools are more for transformations. I may also be missing something about the difference between the 2. 

I've also seen where devs who have built out full MCP servers have just used tools for everything so I don't know if there's really a set precedent here anyways? 

It also seems easier to use a tool I've found using plain language like "search my index for documents about x" which I think you can do with resources but you would need to upload the integration json first